### PR TITLE
lefthook を導入する（hook の内容はまずは空でも OK） (vibe-kanban)

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,11 @@
+pre-commit:
+  parallel: true
+  commands: {}
+
+pre-push:
+  parallel: true
+  commands: {}
+
+commit-msg:
+  commands: {}
+

--- a/package.json
+++ b/package.json
@@ -8,12 +8,15 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint:md": "markdownlint \"**/*.md\"",
-    "prepare": "lefthook install"
+    "prepare": "test \"$CI\" = true || lefthook install"
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "packageManager": "pnpm@10.11.1",
+  "dependencies": {
+    "lefthook": "^1.7.9"
+  },
   "devDependencies": {
     "@types/google-apps-script": "^2.0.0",
     "googleapis": "^159.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "lint:md": "markdownlint \"**/*.md\""
+    "lint:md": "markdownlint \"**/*.md\"",
+    "prepare": "lefthook install"
   },
   "keywords": [],
   "author": "",
@@ -16,6 +17,7 @@
   "devDependencies": {
     "@types/google-apps-script": "^2.0.0",
     "googleapis": "^159.0.0",
+    "lefthook": "^1.7.9",
     "markdownlint-cli": "^0.45.0",
     "prettier": "^3.6.2",
     "typescript": "^5.9.2"


### PR DESCRIPTION
Purpose

Lefthook を導入し、将来的な Git Hooks 自動化の土台を用意する
CI 環境ではインストールをスキップし、ビルド/テストを汚染しない
Changes

lefthook.yml を追加（pre-commit / pre-push / commit-msg は現状空）
package.json を更新
dependencies に lefthook を追加（prepare 実行のため本番依存）
prepare を test "$CI" = true || lefthook install に設定（CI では未実行）

Scope

Git Hooks の土台のみを追加。アプリロジックや GAS コードの挙動変更なし
Before / After

Before: Git Hooks 無し
After: ローカルで pnpm i 実行時に hooks が自動インストール（現状は no-op）
CI（CI=true）では prepare がスキップされ、hooks 未インストール

How To Verify

ローカル
pnpm i を実行し、lefthook install が走ることを確認
pnpm exec lefthook run pre-commit を実行（現状は何も実行されず成功する想定）
git commit --allow-empty -m "test" を試し、commit が問題なく完了することを確認

CI 相当
CI=true pnpm i を実行し、lefthook install が実行されないことを確認

Files

追加: lefthook.yml
変更: package.json
Notes

GAS の権限や設定の変更はありません。秘密情報の追加もありません
今後、lefthook.yml の commands: に Lint / Type Check 等を段階的に追加可能
Next Steps (optional)

pre-commit に pnpm exec tsc --noEmit を追加して型崩れの早期検知
pre-push にフォーマット/静的解析を追加（プロジェクト方針に合わせて相談）