### PR TITLE
fix: disable permission notification emails

### DIFF
--- a/code.gas.js
+++ b/code.gas.js
@@ -406,7 +406,7 @@ const grantEditPermissionToPoGroup = (fileId, fileType) => {
       };
 
       Drive.Permissions.create(permission, fileId, {
-        sendNotificationEmails: false,
+        sendNotificationEmail: false,
       });
 
       logInfo(
@@ -464,7 +464,7 @@ const grantViewPermissionToEstimateMembers = (fileId, fileType) => {
       };
 
       Drive.Permissions.create(permission, fileId, {
-        sendNotificationEmails: false,
+        sendNotificationEmail: false,
       });
 
       logInfo(


### PR DESCRIPTION
## Summary
- correct Drive.Permissions option to `sendNotificationEmail: false` when granting edit or view access so users aren't notified

## Testing
- `mise install`
- `pnpm i`
- `pnpm exec tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68be5023574883218bdeced011f5131f