### PR TITLE
fix: use Logger instead of console in debug table runner

### DIFF
--- a/code.gas.js
+++ b/code.gas.js
@@ -3020,12 +3020,12 @@ const getEstimateDebugMap = () => {
 };
 
 /**
- * デバッグ用: テーブル「見積もり必要_デバッグ」を読み込み console.log する。
+ * デバッグ用: テーブル「見積もり必要_デバッグ」を読み込み logInfo する。
  * 使用例: runDebugEstimateDebugTable()
  */
 const runDebugEstimateDebugTable = () =>
   safeMain("runDebugEstimateDebugTable", () => {
     const map = getEstimateDebugMap();
-    console.log(map);
+    logInfo("Estimate debug map", map);
     return map;
   });


### PR DESCRIPTION
## Summary
- replace `console.log` with `logInfo` in `runDebugEstimateDebugTable`
- update doc comment to reflect logging change

## Testing
- `pnpm exec tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68c02cdd70e48321bf7e7da96e1dc3e9