### PR TITLE
fix: ignore blank rows in estimate issue table

### DIFF
--- a/code.gas.js
+++ b/code.gas.js
@@ -749,7 +749,7 @@ const createEstimateFromTemplates = (deadlineDate) => {
   });
 
   // Google Formのタイトルとセクションをセットアップ
-  const issueList = getEstimateIssueList();
+  const issueList = getEstimateIssueList().filter(({ title, url }) => title || url);
   setupFormSections(formUrl, titlePrefix, issueList);
 
   logInfo("Form sections setup completed", {
@@ -1676,7 +1676,7 @@ const updateResultSummaryTable = (spreadsheetUrl) => {
   });
 
   // 見積もり課題リストを取得
-  const issueList = getEstimateIssueList();
+  const issueList = getEstimateIssueList().filter(({ title, url }) => title || url);
   logInfo("Retrieved estimate issue list", {
     count: issueList.length,
   });
@@ -2414,9 +2414,6 @@ const getEstimateIssueList = () => {
   const rows = [];
   for (let i = 1; i < values.length; i++) {
     const row = values[i] || [];
-    if (row.every((cell) => String(cell).trim() === "")) {
-      continue;
-    }
     const title = String(row[titleIdx] ?? "").trim();
     const url = String(row[urlIdx] ?? "").trim();
 
@@ -3017,7 +3014,7 @@ const runDebugFormSetup = () =>
     logInfo("Debug: Form copied successfully", { formUrl });
 
     // 見積もり課題の数を取得
-    const issueList = getEstimateIssueList();
+    const issueList = getEstimateIssueList().filter(({ title, url }) => title || url);
     const issueCount = issueList.length;
     logInfo("Debug: Retrieved issue list", { issueCount });
 


### PR DESCRIPTION
## Summary
- skip completely empty rows when loading `見積もり必要_課題リスト`

## Testing
- `pnpm exec tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68c0f6f39e308321ae24c7de71a107a0